### PR TITLE
feat: Apply BE API within room matching and set router

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         specifier: ^7.56.3
         version: 7.56.3(react@19.1.0)
       react-router:
-        specifier: ^7.5.2
+        specifier: ^7.5.0
         version: 7.6.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tailwind-merge:
         specifier: ^3.2.0
@@ -175,7 +175,7 @@ importers:
         specifier: ^8.24.1
         version: 8.30.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.7.3)
       vite:
-        specifier: ^6.3.4
+        specifier: ^6.2.0
         version: 6.3.5(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(yaml@2.8.0)
       vitest:
         specifier: ^3.1.2

--- a/src/components/Lobby/RoomSearchModal.tsx
+++ b/src/components/Lobby/RoomSearchModal.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 
-import { useNavigate } from "react-router";
+import { useGameSession } from "@/contexts/GameSessionContext";
+import { useSocketRequest } from "@/contexts/SocketContext";
+import { setRoomSession } from "@/libs/game/sessionUtils";
 
 interface RoomSearchModalProps {
   isOpen: boolean;
@@ -9,7 +11,23 @@ interface RoomSearchModalProps {
 
 const RoomSearchModal = ({ isOpen, onClose }: RoomSearchModalProps) => {
   const [value, setValue] = useState("");
-  const navigate = useNavigate();
+
+  const { setRoomId, setCapacity, setParticipants } = useGameSession();
+
+  const searchRoom = useSocketRequest(
+    "search_room_by_code",
+    "room_search_result",
+  );
+
+  const clickSearch = async () => {
+    try {
+      const result = await searchRoom({ room_code: value });
+      setRoomSession(result.room, { setRoomId, setCapacity, setParticipants });
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
   if (!isOpen) return null;
 
   return (
@@ -71,9 +89,7 @@ const RoomSearchModal = ({ isOpen, onClose }: RoomSearchModalProps) => {
             className="btn w-full btn-primary"
             onClick={() => {
               if (value.length === 4) {
-                // 방 찾기 로직을 여기에 추가
-                navigate("/waiting");
-                onClose(); // 모달 닫기
+                clickSearch();
               }
             }}
           >

--- a/src/contexts/GameSessionContext.tsx
+++ b/src/contexts/GameSessionContext.tsx
@@ -1,9 +1,12 @@
 import { createContext, Provider, useContext } from "react";
 
-interface GameSessionContext {
+export interface GameSessionContext {
   roomId: string;
   participants: string[];
+  capacity: number;
   setParticipants: React.Dispatch<React.SetStateAction<string[]>>;
+  setRoomId: React.Dispatch<React.SetStateAction<string>>;
+  setCapacity: React.Dispatch<React.SetStateAction<number>>;
 }
 
 const GameSessionContext = createContext<GameSessionContext | null>(null);

--- a/src/layouts/GameSessionLayout.tsx
+++ b/src/layouts/GameSessionLayout.tsx
@@ -1,36 +1,43 @@
 import { useEffect, useState } from "react";
 
-import { Navigate, Outlet, useParams } from "react-router";
+import { Outlet, useParams } from "react-router";
 
 import { GameSessionProvider } from "@/contexts/GameSessionContext";
 import { useAuthenticated } from "@/contexts/SessionContext";
 import { useSocketEmitter } from "@/contexts/SocketContext";
+import LobbyPage from "@/pages/LobbyPage";
 
 export const GameSessionLayout = () => {
-  const roomId = useParams<{ roomId: string }>().roomId;
-  if (!roomId) return <Navigate to={{ pathname: "/" }} replace />;
-
-  return <GameSessionLayoutInner roomId={roomId}></GameSessionLayoutInner>;
-};
-
-const GameSessionLayoutInner = ({ roomId }: { roomId: string }) => {
+  const { roomId: paramRoomId } = useParams<{ roomId?: string }>();
   const { userId } = useAuthenticated();
+
   const [participants, setParticipants] = useState<string[]>([]);
+  const [roomId, setRoomId] = useState<string>(paramRoomId ?? "");
+  const [capacity, setCapacity] = useState<number>(-1);
 
   const joinGame = useSocketEmitter("join_game");
   const leaveRoom = useSocketEmitter("leave_room");
 
   useEffect(() => {
-    joinGame({ room: roomId, player: userId });
+    joinGame({ requestId: "11", room: roomId, player: userId });
 
     return () => {
-      leaveRoom({ room: roomId, player: userId });
+      leaveRoom({ requestId: "11", room: roomId, player: userId });
     };
   }, [joinGame, leaveRoom, roomId, userId]);
 
   return (
-    <GameSessionProvider value={{ roomId, participants, setParticipants }}>
-      <Outlet />
+    <GameSessionProvider
+      value={{
+        roomId,
+        participants,
+        capacity,
+        setRoomId,
+        setCapacity,
+        setParticipants,
+      }}
+    >
+      {roomId ? <Outlet /> : <LobbyPage />}
     </GameSessionProvider>
   );
 };

--- a/src/libs/game/sessionUtils.ts
+++ b/src/libs/game/sessionUtils.ts
@@ -1,0 +1,14 @@
+// src/libs/gameSessionUtils.ts
+import { GameSessionContext } from "@/contexts/GameSessionContext";
+
+export const setRoomSession = (
+  room: { room_id: string; max_players: number; players: string[] },
+  setters: Pick<
+    GameSessionContext,
+    "setRoomId" | "setCapacity" | "setParticipants"
+  >,
+) => {
+  setters.setRoomId(room.room_id);
+  setters.setCapacity(room.max_players);
+  setters.setParticipants(room.players);
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,13 +21,11 @@ createRoot(document.getElementById("root")!).render(
         <BrowserRouter>
           <Routes>
             <Route path="/login" element={<LoginPage />} />
-
             <Route path="/" element={<AuthenticatedLayout />}>
-              <Route index element={<LobbyPage />} />
-              <Route path=":gameId" element={<GameSessionLayout />}>
-                <Route path="waiting" element={<WaitingRoom />} />
-                {/* Nested route for the game page */}
-                <Route path="game" element={<Game />} />
+              <Route element={<GameSessionLayout />}>
+                <Route index element={<LobbyPage />} />
+                <Route path="waiting/:roomId" element={<WaitingRoom />} />
+                <Route path="game/:roomId" element={<Game />} />
               </Route>
             </Route>
           </Routes>

--- a/src/pages/WaitingRoom.tsx
+++ b/src/pages/WaitingRoom.tsx
@@ -7,7 +7,6 @@ import { useGameSession } from "@/contexts/GameSessionContext";
 
 const WaitingRoom = () => {
   const navigate = useNavigate();
-  // const [participants, setParticipants] = useState<string[]>(["Plyayer1"]);
   const [countdown, setCountdown] = useState<number | null>(null);
   const palette = [
     "bg-blue-300",
@@ -22,16 +21,13 @@ const WaitingRoom = () => {
     "bg-teal-200",
   ];
 
-  // const { roomId, capacity, socket } = useGameSession();
-  const { roomId, participants, setParticipants } = useGameSession();
-  const capacity = 10; // 임시로 정원 10명으로 설정
+  const { roomId, capacity, participants, setParticipants } = useGameSession();
 
-  // 0.5초마다 참가자 1명씩 추가 (총 10명까지)
+  // 0.5초마다 참가자 1명씩 추가 (총 10명까지) DUMMY
   useEffect(() => {
-    let count = 1;
-    setParticipants(["Player1"]);
+    let count = participants.length;
     const interval = setInterval(() => {
-      if (count < 10) {
+      if (count < capacity) {
         count += 1;
         setParticipants((prev) => [...prev, `Player${count}`]);
       } else {
@@ -40,7 +36,7 @@ const WaitingRoom = () => {
     }, 500);
 
     return () => clearInterval(interval);
-  }, [setParticipants]);
+  }, [capacity, participants.length, setParticipants]);
 
   // useEffect(() => {
   //   const handleParticipantsUpdate = (data: string[]) => {
@@ -69,8 +65,8 @@ const WaitingRoom = () => {
       return () => clearTimeout(id);
     }
     // 카운트 종료 시 게임 페이지로 이동
-    navigate("/game");
-  }, [countdown, navigate]);
+    navigate(`/game/${roomId}`);
+  }, [countdown, navigate, roomId]);
 
   const handleCancel = () => {
     navigate("/");

--- a/src/services/socket/event.response.ts
+++ b/src/services/socket/event.response.ts
@@ -18,18 +18,65 @@ export interface ListenEvents {
   username_result: (data: ListenEvent<{ username: string }>) => void;
 
   room_created: (
-    data: ListenEvent<{ room: { room_id: string }; room_id: string }>,
+    data: ListenEvent<{
+      room: {
+        room_id: string;
+        host: string;
+        is_public: boolean;
+        max_players: number;
+        card_helper: boolean;
+        players: string[];
+        player_count: number;
+        is_started: boolean;
+      };
+      room_id: string;
+    }>,
   ) => void;
 
   room_search_result: (
-    data: ListenEvent<{ room: { room_id: string } }>,
+    data: ListenEvent<{
+      room: {
+        room_id: string;
+        host: string;
+        is_public: boolean;
+        max_players: number;
+        card_helper: boolean;
+        players: string[];
+        player_count: number;
+        is_started: boolean;
+      };
+    }>,
   ) => void;
 
   quick_match_result: (
-    data: ListenEvent<{ room: { room_id: string } }>,
+    data: ListenEvent<{
+      room: {
+        room_id: string;
+        host: string;
+        is_public: boolean;
+        max_players: number;
+        card_helper: boolean;
+        players: string[];
+        player_count: number;
+        is_started: boolean;
+      };
+    }>,
   ) => void;
 
-  join_room_result: (data: ListenEvent<{ room: { room_id: string } }>) => void;
+  join_room_result: (
+    data: ListenEvent<{
+      room: {
+        room_id: string;
+        host: string;
+        is_public: boolean;
+        max_players: number;
+        card_helper: boolean;
+        players: string[];
+        player_count: number;
+        is_started: boolean;
+      };
+    }>,
+  ) => void;
 
   game_update: (data: SocketAction.Response.Broadcast.Primitive) => void;
   private_game_update: (data: SocketAction.Response.Private.Primitive) => void;


### PR DESCRIPTION
<!-- PR에 Assignee, Lables를 설정하세요. -->

## Jira Task: SWPF-65, SWPF-66, SWPF-68

<!--
  * Jira Task에 `,`를 사용해서 연동될 Task key를 나열하세요. e.g.) SWPF-001, SWPF-002
  * 아래 설명에는 [Task Key]: [Task Name] 형식을 불렛으로 나열하세요.

  주의!! 하나의 PR을 올리더라도, 연동되는 Task Key는 전부 포함해 주세요.
-->

- SWPF-65 [FE_Fetch] 빠른 매칭
- SWPF-66 [FE_Fetch] 방 생성
- SWPF-68 [FE_Fetch] 방 코드 검색

## Content

<!-- 태스크 내용을 상세히 기재하세요. -->

- `playerNum`, `isPublic`, `helper`, `capacity` 등을 로비 > 웨이팅 페이지 > 게임 방까지 정보 전달할 수 있도록 컨텍스트 수정
- GameSessionProvider 아래에 위치해야 하므로 main.tsx 라우팅 수정
- `gameId` > `roomId` 로 변수명 통합 및 라우팅 적용
- 실제 API res에 따라 src/services/socket/event.response.ts 수정
