### PR TITLE
refactor: actions

### DIFF
--- a/src/libs/saboteur/adapter/action/index.ts
+++ b/src/libs/saboteur/adapter/action/index.ts
@@ -202,36 +202,29 @@ export namespace SaboteurAction {
       export class Destroy extends Response.Primitive<{
         x: number;
         y: number;
-        card: SaboteurCard.Action.Destroy;
       }> {
         static readonly type = "destroy";
       }
 
       export class Repair extends Response.Primitive<{
-        card: SaboteurCard.Action.Repair;
-        player: AbstractSaboteurPlayer;
+        tool: Tools;
+        playerId: string;
       }> {
         static readonly type = "repair";
       }
 
       export class Sabotage extends Response.Primitive<{
-        card: SaboteurCard.Action.Sabotage;
-        player: AbstractSaboteurPlayer;
+        tool: Tools;
+        playerId: string;
       }> {
         static readonly type = "sabotage";
       }
 
-      export class UseMap extends Response.Primitive<{
-        x: number;
-        y: number;
-        card: SaboteurCard.Action.Map;
-      }> {
+      export class UseMap extends Response.Primitive<{ x: number; y: number }> {
         static readonly type = "useMap";
       }
 
-      export class Discard extends Response.Primitive<{
-        card: SaboteurCard.Abstract.Playable;
-      }> {
+      export class Discard extends Response.Primitive<{ handIndex: number }> {
         static readonly type = "discard";
       }
 
@@ -249,14 +242,12 @@ export namespace SaboteurAction {
         static readonly type = "gameStart";
       }
 
-      export class TurnChange extends Response.Primitive<{
-        player: AbstractSaboteurPlayer;
-      }> {
+      export class TurnChange extends Response.Primitive<{ playerId: string }> {
         static readonly type = "turnChange";
       }
 
       export class GameEnd extends Response.Primitive<{
-        rank: { player: AbstractSaboteurPlayer; gold: number }[];
+        golds: { [playerId: string]: number };
       }> {
         static readonly type = "gameEnd";
       }
@@ -271,6 +262,7 @@ export namespace SaboteurAction {
         | typeof FoundRock
         | typeof GameStart
         | typeof TurnChange
+        | typeof RoundEnd
         | typeof GameEnd;
       export type Actions = InstanceType<ActionClass>;
       export type ActionType = ActionClass["type"];
@@ -296,7 +288,7 @@ export namespace SaboteurAction {
         y: number;
         card: SaboteurCard.Path.AbstractDest;
       }> {
-        static readonly type = "reveal Dest";
+        static readonly type = "revealDest";
       }
 
       export class Rotate extends Response.Primitive<{
@@ -305,20 +297,12 @@ export namespace SaboteurAction {
         static readonly type = "rotate";
       }
 
-      export class RoundEnd extends Response.Primitive<{
-        winners: AbstractSaboteurPlayer[];
-      }> {
-        static readonly type = "roundEnd";
-      }
-
       export class PlayerState extends Response.Primitive<{
         round: number;
         myPlayer: {
-          id: string;
           gold: number;
           role: PlayerRole | null;
           hands: SaboteurCard.Abstract.Playable[];
-          status: Record<Tools, boolean>;
         };
         currentPlayerId: string;
         players: {
@@ -331,10 +315,7 @@ export namespace SaboteurAction {
         static readonly type = "playerState";
       }
 
-      export class ReceiveGold extends Response.Primitive<{
-        player: AbstractSaboteurPlayer;
-        gold: number;
-      }> {
+      export class ReceiveGold extends Response.Primitive<{ gold: number }> {
         static readonly type = "receiveGold";
       }
 
@@ -343,7 +324,6 @@ export namespace SaboteurAction {
         | typeof Draw
         | typeof RevealDest
         | typeof Rotate
-        | typeof RoundEnd
         | typeof PlayerState
         | typeof ReceiveGold;
       export type Actions = InstanceType<ActionClass>;

--- a/src/libs/saboteur/adapter/adapter.interface.ts
+++ b/src/libs/saboteur/adapter/adapter.interface.ts
@@ -19,11 +19,9 @@ export interface SaboteurSessionAdapter extends GameSessionAdapter {
   >(
     actionType: TActionType,
     callback: (action: InstanceType<TActionClass>) => void,
-    gameSession: SaboteurSession,
   ): UnsubscribeCallback;
 
   onAny(
     callback: (action: SaboteurAction.Response.Actions) => void,
-    gameSession: SaboteurSession,
   ): UnsubscribeCallback;
 }

--- a/src/libs/saboteur/game.ts
+++ b/src/libs/saboteur/game.ts
@@ -11,7 +11,6 @@ import { GameBoard } from "@/libs/saboteur/board";
 import {
   AbstractSaboteurPlayer,
   MySaboteurPlayer,
-  OtherSaboteurPlayer,
 } from "@/libs/saboteur/player";
 import { UnsubscribeCallback } from "@/libs/socket-io";
 
@@ -120,27 +119,9 @@ export class SaboteurSession implements GameSession {
     this.players = players;
     this.board = new GameBoard();
 
-    this.adapter.on(
-      "roundStart",
-      (data) => {
-        this.onRoundStart(data);
-      },
-      this,
-    );
-    this.adapter.on(
-      "turnChange",
-      (data) => {
-        this.onTurnChange(data);
-      },
-      this,
-    );
-    this.adapter.on(
-      "roundEnd",
-      (data) => {
-        this.onRoundEnd(data);
-      },
-      this,
-    );
+    this.adapter.onAny((action) => {
+      action.update(this);
+    });
   }
 
   get currentPlayer(): AbstractSaboteurPlayer {
@@ -169,34 +150,24 @@ export class SaboteurSession implements GameSession {
     this.adapter.sendAction(action, this);
   }
 
-  private onRoundStart({ data }: SaboteurAction.Response.Private.RoundStart) {
-    this.round = data.round;
+  // private onRoundStart({ data }: SaboteurAction.Response.Private.RoundStart) {
+  //   this.round = data.round;
 
-    data.hands.forEach((card) => this.myPlayer.add(card));
-    this.myPlayer.role = data.role;
+  //   data.hands.forEach((card) => this.myPlayer.add(card));
+  //   this.myPlayer.role = data.role;
 
-    this.players.forEach((player) => {
-      if (player instanceof OtherSaboteurPlayer)
-        player.handCount = OtherSaboteurPlayer.getInitialHandCount(
-          this.players.length,
-        );
-    });
-  }
+  //   this.players.forEach((player) => {
+  //     if (player instanceof OtherSaboteurPlayer)
+  //       player.handCount = OtherSaboteurPlayer.getInitialHandCount(
+  //         this.players.length,
+  //       );
+  //   });
+  // }
 
-  private onTurnChange({
-    data: { player },
-  }: SaboteurAction.Response.Public.TurnChange) {
-    const nextPlayerIndex = this.players.findIndex((p) => p.id === player.id);
-    if (nextPlayerIndex === -1) {
-      throw new Error(`Player ${player.id} not found in the game state.`);
-    }
-    this._currentPlayerIndex = nextPlayerIndex;
-  }
-
-  private onRoundEnd({ data }: SaboteurAction.Response.Private.RoundEnd) {
-    this.players.forEach((player) => {
-      player.resetRoundState();
-    });
-  }
+  // private onRoundEnd({ data }: SaboteurAction.Response.Private.RoundEnd) {
+  //   this.players.forEach((player) => {
+  //     player.resetRoundState();
+  //   });
+  // }
 }
 export interface SaboteurSession extends Reactive {}

--- a/src/libs/saboteur/player.ts
+++ b/src/libs/saboteur/player.ts
@@ -39,10 +39,8 @@ export abstract class AbstractSaboteurPlayer implements GameSessionPlayer {
     this._status[tool] = false;
   }
 
-  repair(tools: Tools[]): void {
-    tools.forEach((tool) => {
-      this._status[tool] = true;
-    });
+  repair(tool: Tools): void {
+    this._status[tool] = true;
   }
 
   resetRoundState(): void {


### PR DESCRIPTION
- 불변성을 위해 `toSaboteurAction`에서 `gameSession`을 받지 않도록 수정
- 서버와 맞지 않는 타입 수정
- `gameSession`의 업데이트를 각 action 클래스의 update 함수에 위임